### PR TITLE
Recent edits to json formatter, css loads before html, new tests

### DIFF
--- a/src/json-formatter/json-formatter-tool.css
+++ b/src/json-formatter/json-formatter-tool.css
@@ -127,6 +127,11 @@
 .download-btn:active {
 	transform: scale(0.98);
 }
+.copy-btn:disabled,
+.download-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 @media (max-width: 600px) {
 	.tool-panel {

--- a/src/json-formatter/json-formatter-tool.css
+++ b/src/json-formatter/json-formatter-tool.css
@@ -62,6 +62,51 @@
   ); /* Light/Dark mode read-only background */
 }
 
+.notification-wrapper {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  pointer-events: none;
+}
+
+.notification {
+  position: relative;
+  background-color: green;
+  color: white;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+  white-space: nowrap;
+  margin-bottom: 10px;
+}
+
+.notification::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid green;
+}
+
+.notification.show {
+  opacity: 1;
+}
+
+.copy-btn-container,
+.download-btn-container {
+  position: relative;
+  display: inline-block;
+}
+
 /* Format button styling */
 .format-btn {
   align-self: center;
@@ -165,5 +210,10 @@ textarea::placeholder {
   .button-group {
     flex-direction: column; /* Stack buttons vertically on smaller screens */
     gap: 10px; /* Adjust spacing for mobile view */
+  }
+
+  .notification {
+    font-size: 12px;
+    padding: 6px 12px;
   }
 }

--- a/src/json-formatter/json-formatter-tool.css
+++ b/src/json-formatter/json-formatter-tool.css
@@ -1,148 +1,148 @@
 /* Container for the JSON Formatter tool */
 
 .tool-panel {
-  display: flex;
-  flex: 1;
-  width: 100%;
-  height: 90%;
-  margin: 20px auto;
-  background: #ffffff;
-  border-radius: 8px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-  z-index: 1000;
-  overflow: auto;
-  flex-direction: column;
+	display: flex !important;
+	flex: 1;
+	width: 100%;
+	height: 90%;
+	margin: 20px auto;
+	background: #ffffff;
+	border-radius: 8px;
+	box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+	z-index: 1000;
+	overflow: auto;
+	flex-direction: column;
 }
 
 /* Header styling */
 .tool-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 15px;
-  background-color: #061524;
-  color: #ffffff;
-  font-size: calc(var(--font-size-desktop) * 1.2);
-  font-weight: bold;
-  border-bottom: 1px solid #ddd;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 15px;
+	background-color: #061524;
+	color: #ffffff;
+	font-size: calc(var(--font-size-desktop) * 1.2);
+	font-weight: bold;
+	border-bottom: 1px solid #ddd;
 }
 
 /* Tool content styling */
 .tool-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 20px;
-  background-color: #f9f9f9;
-  color: #333333;
-  gap: 20px;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	padding: 20px;
+	background-color: #f9f9f9;
+	color: #333333;
+	gap: 20px;
 }
 
 /* Input and output text areas */
 .input-area,
 .output-area {
-  flex: 1;
-  padding: 10px;
-  border: 1px solid #dddddd;
-  border-radius: 4px;
-  font-family: monospace;
-  font-size: calc(var(--font-size-desktop) * 1);
-  resize: none;
+	flex: 1;
+	padding: 10px;
+	border: 1px solid #dddddd;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: calc(var(--font-size-desktop) * 1);
+	resize: none;
 }
 
 /* Read-only style for output area */
 .output-area[readonly] {
-  background-color: #e9e9e9;
+	background-color: #e9e9e9;
 }
 
 /* Format button styling */
 .format-btn {
-  align-self: center;
-  padding: 10px 20px;
-  background-color: #061524;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: calc(var(--font-size-desktop) * 1);
-  transition:
-    background-color 0.3s ease,
-    transform 0.2s ease;
+	align-self: center;
+	padding: 10px 20px;
+	background-color: #061524;
+	color: #ffffff;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: calc(var(--font-size-desktop) * 1);
+	transition:
+		background-color 0.3s ease,
+		transform 0.2s ease;
 }
 
 .format-btn:hover {
-  background-color: #34495e;
-  transform: scale(1.05);
+	background-color: #34495e;
+	transform: scale(1.05);
 }
 
 .upload-btn {
-  display: inline-block;
-  padding: 10px 15px;
-  background-color: #061524;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: calc(var(--font-size-desktop) * 1);
-  transition: background 0.3s ease;
-  min-width: 100px;
-  text-align: center;
-  max-width: 250px;
+	display: inline-block;
+	padding: 10px 15px;
+	background-color: #061524;
+	color: #ffffff;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: calc(var(--font-size-desktop) * 1);
+	transition: background 0.3s ease;
+	min-width: 100px;
+	text-align: center;
+	max-width: 250px;
 }
 
 .upload-btn:hover {
-  background-color: #34495e;
+	background-color: #34495e;
 }
 
 /* Button group styling */
 .button-group {
-  display: flex;
-  justify-content: center;
-  gap: 15px;
-  /* Add space between buttons */
+	display: flex;
+	justify-content: center;
+	gap: 15px;
+	/* Add space between buttons */
 }
 
 .copy-btn,
 .download-btn {
-  align-self: center;
-  padding: 10px 30px;
-  background-color: #061524;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: calc(var(--font-size-desktop) * 1);
-  transition:
-    background-color 0.3s ease,
-    transform 0.2s ease;
+	align-self: center;
+	padding: 10px 30px;
+	background-color: #061524;
+	color: #ffffff;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: calc(var(--font-size-desktop) * 1);
+	transition:
+		background-color 0.3s ease,
+		transform 0.2s ease;
 }
 
 .copy-btn:hover,
 .download-btn:hover {
-  background-color: #34495e;
-  transform: scale(1.05);
+	background-color: #34495e;
+	transform: scale(1.05);
 }
 
 .copy-btn:active,
 .download-btn:active {
-  transform: scale(0.98);
+	transform: scale(0.98);
 }
 
 @media (max-width: 600px) {
-  .tool-panel {
-    font-size: var(--font-size-mobile);
-    /* Mobile font size */
-  }
+	.tool-panel {
+		font-size: var(--font-size-mobile);
+		/* Mobile font size */
+	}
 
-  .tool-header {
-    font-size: var(--font-size-mobile);
-    /* Mobile font size */
-  }
+	.tool-header {
+		font-size: var(--font-size-mobile);
+		/* Mobile font size */
+	}
 
-  .button-group {
-    flex-direction: column;
-    /* Stack buttons vertically on smaller screens */
-    gap: 10px;
-    /* Adjust spacing for mobile view */
-  }
+	.button-group {
+		flex-direction: column;
+		/* Stack buttons vertically on smaller screens */
+		gap: 10px;
+		/* Adjust spacing for mobile view */
+	}
 }

--- a/src/json-formatter/json-formatter-tool.css
+++ b/src/json-formatter/json-formatter-tool.css
@@ -1,131 +1,131 @@
 /* Container for the JSON Formatter tool */
 
 .tool-panel {
-	display: flex !important;
-	flex: 1;
-	width: 100%;
-	height: 90%;
-	margin: 20px auto;
-	background: #ffffff;
-	border-radius: 8px;
-	box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-	z-index: 1000;
-	overflow: auto;
-	flex-direction: column;
+  display: flex !important;
+  flex: 1;
+  width: 100%;
+  height: 90%;
+  margin: 20px auto;
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  overflow: auto;
+  flex-direction: column;
 }
 
 /* Header styling */
 .tool-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 15px;
-	background-color: #061524;
-	color: #ffffff;
-	font-size: calc(var(--font-size-desktop) * 1.2);
-	font-weight: bold;
-	border-bottom: 1px solid #ddd;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px;
+  background-color: #061524;
+  color: #ffffff;
+  font-size: calc(var(--font-size-desktop) * 1.2);
+  font-weight: bold;
+  border-bottom: 1px solid #ddd;
 }
 
 /* Tool content styling */
 .tool-content {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	padding: 20px;
-	background-color: #f9f9f9;
-	color: #333333;
-	gap: 20px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  background-color: #f9f9f9;
+  color: #333333;
+  gap: 20px;
 }
 
 /* Input and output text areas */
 .input-area,
 .output-area {
-	flex: 1;
-	padding: 10px;
-	border: 1px solid #dddddd;
-	border-radius: 4px;
-	font-family: monospace;
-	font-size: calc(var(--font-size-desktop) * 1);
-	resize: none;
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #dddddd;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: calc(var(--font-size-desktop) * 1);
+  resize: none;
 }
 
 /* Read-only style for output area */
 .output-area[readonly] {
-	background-color: #e9e9e9;
+  background-color: #e9e9e9;
 }
 
 /* Format button styling */
 .format-btn {
-	align-self: center;
-	padding: 10px 20px;
-	background-color: #061524;
-	color: #ffffff;
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: calc(var(--font-size-desktop) * 1);
-	transition:
-		background-color 0.3s ease,
-		transform 0.2s ease;
+  align-self: center;
+  padding: 10px 20px;
+  background-color: #061524;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(var(--font-size-desktop) * 1);
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 }
 
 .format-btn:hover {
-	background-color: #34495e;
-	transform: scale(1.05);
+  background-color: #34495e;
+  transform: scale(1.05);
 }
 
 .upload-btn {
-	display: inline-block;
-	padding: 10px 15px;
-	background-color: #061524;
-	color: #ffffff;
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: calc(var(--font-size-desktop) * 1);
-	transition: background 0.3s ease;
-	min-width: 100px;
-	text-align: center;
-	max-width: 250px;
+  display: inline-block;
+  padding: 10px 15px;
+  background-color: #061524;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(var(--font-size-desktop) * 1);
+  transition: background 0.3s ease;
+  min-width: 100px;
+  text-align: center;
+  max-width: 250px;
 }
 
 .upload-btn:hover {
-	background-color: #34495e;
+  background-color: #34495e;
 }
 
 /* Button group styling */
 .button-group {
-	display: flex;
-	justify-content: center;
-	gap: 15px;
-	/* Add space between buttons */
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  /* Add space between buttons */
 }
 
 .copy-btn,
 .download-btn {
-	align-self: center;
-	padding: 10px 30px;
-	background-color: #061524;
-	color: #ffffff;
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: calc(var(--font-size-desktop) * 1);
-	transition:
-		background-color 0.3s ease,
-		transform 0.2s ease;
+  align-self: center;
+  padding: 10px 30px;
+  background-color: #061524;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(var(--font-size-desktop) * 1);
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 }
 
 .copy-btn:hover,
 .download-btn:hover {
-	background-color: #34495e;
-	transform: scale(1.05);
+  background-color: #34495e;
+  transform: scale(1.05);
 }
 
 .copy-btn:active,
 .download-btn:active {
-	transform: scale(0.98);
+  transform: scale(0.98);
 }
 .copy-btn:disabled,
 .download-btn:disabled {
@@ -134,20 +134,20 @@
 }
 
 @media (max-width: 600px) {
-	.tool-panel {
-		font-size: var(--font-size-mobile);
-		/* Mobile font size */
-	}
+  .tool-panel {
+    font-size: var(--font-size-mobile);
+    /* Mobile font size */
+  }
 
-	.tool-header {
-		font-size: var(--font-size-mobile);
-		/* Mobile font size */
-	}
+  .tool-header {
+    font-size: var(--font-size-mobile);
+    /* Mobile font size */
+  }
 
-	.button-group {
-		flex-direction: column;
-		/* Stack buttons vertically on smaller screens */
-		gap: 10px;
-		/* Adjust spacing for mobile view */
-	}
+  .button-group {
+    flex-direction: column;
+    /* Stack buttons vertically on smaller screens */
+    gap: 10px;
+    /* Adjust spacing for mobile view */
+  }
 }

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -1,27 +1,27 @@
 class JsonFormatterTool extends HTMLElement {
-	/**
-	 * Initializes a new instance of JsonFormatterTool.
-	 * Sets up initial properties for toolPanel, formatBtn, inputArea, and outputArea as null.
-	 */
-	constructor() {
-		super();
-		this.toolPanel = null;
-		this.formatBtn = null;
-		this.inputArea = null;
-		this.outputArea = null;
-		this.copyBtn = null;
-		this.downloadBtn = null;
-		this.uploadBtn = null;
-	}
+  /**
+   * Initializes a new instance of JsonFormatterTool.
+   * Sets up initial properties for toolPanel, formatBtn, inputArea, and outputArea as null.
+   */
+  constructor() {
+    super();
+    this.toolPanel = null;
+    this.formatBtn = null;
+    this.inputArea = null;
+    this.outputArea = null;
+    this.copyBtn = null;
+    this.downloadBtn = null;
+    this.uploadBtn = null;
+  }
 
-	/**
-	 * Called when the element is added to the DOM.
-	 * Sets up the HTML structure of the tool and stores references to elements.
-	 * Binds event listeners for the "Format" button.
-	 */
-	connectedCallback() {
-		// Set up the HTML structure when the element is added to the DOM
-		this.innerHTML = `
+  /**
+   * Called when the element is added to the DOM.
+   * Sets up the HTML structure of the tool and stores references to elements.
+   * Binds event listeners for the "Format" button.
+   */
+  connectedCallback() {
+    // Set up the HTML structure when the element is added to the DOM
+    this.innerHTML = `
       <link rel="stylesheet" href="json-formatter/json-formatter-tool.css" > 
       <section class="tool-panel" style="display:none;">
         <header class="tool-header">
@@ -40,20 +40,19 @@ class JsonFormatterTool extends HTMLElement {
       </section>
       `;
 
-		// Store references to elements
-		this.toolPanel = this.querySelector(".tool-panel");
-		this.formatBtn = this.querySelector(".format-btn");
-		this.inputArea = this.querySelector(".input-area");
-		this.outputArea = this.querySelector(".output-area");
-		this.copyBtn = this.querySelector(".copy-btn");
-		this.downloadBtn = this.querySelector(".download-btn");
+    // Store references to elements
+    this.toolPanel = this.querySelector(".tool-panel");
+    this.formatBtn = this.querySelector(".format-btn");
+    this.inputArea = this.querySelector(".input-area");
+    this.outputArea = this.querySelector(".output-area");
+    this.copyBtn = this.querySelector(".copy-btn");
+    this.downloadBtn = this.querySelector(".download-btn");
 
-		// Bind event listeners
-		this.formatBtn.addEventListener("click", this.formatJson);
-		this.copyBtn.addEventListener("click", this.copyToClipboard.bind(this));
-		this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
-	}
-
+    // Bind event listeners
+    this.formatBtn.addEventListener("click", this.formatJson);
+    this.copyBtn.addEventListener("click", this.copyToClipboard.bind(this));
+    this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
+  }
 
   /**
    * Formats the input JSON and updates the output area.
@@ -77,48 +76,47 @@ class JsonFormatterTool extends HTMLElement {
     }
   };
 
-	/**
-	 * Cleans up event listeners when the element is removed from the DOM.
-	 * @see https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks
-	 */
-	disconnectedCallback() {
-		// Clean up event listeners when the element is removed from the DOM
-		if (this.formatBtn)
-			this.formatBtn.removeEventListener("click", this.formatJson);
-		if (this.copyBtn)
-			this.copyBtn.removeEventListener("click", this.copyToClipboard);
-		if (this.downloadBtn)
-			this.downloadBtn.removeEventListener("click", this.downloadJson);
-		if (this.uploadBtn)
-			this.uploadBtn.removeEventListener("change", this.handleFileUpload);
-	}
-	copyToClipboard() {
-		const output = this.outputArea.value;
-		if (output) {
-			navigator.clipboard
-				.writeText(output)
-				.then(() => alert("Formatted JSON copied to clipboard!"))
-				.catch(() => alert("Failed to copy JSON to clipboard."));
-		} else {
-			alert("Nothing to copy!");
-		}
-	}
+  /**
+   * Cleans up event listeners when the element is removed from the DOM.
+   * @see https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks
+   */
+  disconnectedCallback() {
+    // Clean up event listeners when the element is removed from the DOM
+    if (this.formatBtn)
+      this.formatBtn.removeEventListener("click", this.formatJson);
+    if (this.copyBtn)
+      this.copyBtn.removeEventListener("click", this.copyToClipboard);
+    if (this.downloadBtn)
+      this.downloadBtn.removeEventListener("click", this.downloadJson);
+    if (this.uploadBtn)
+      this.uploadBtn.removeEventListener("change", this.handleFileUpload);
+  }
+  copyToClipboard() {
+    const output = this.outputArea.value;
+    if (output) {
+      navigator.clipboard
+        .writeText(output)
+        .then(() => alert("Formatted JSON copied to clipboard!"))
+        .catch(() => alert("Failed to copy JSON to clipboard."));
+    } else {
+      alert("Nothing to copy!");
+    }
+  }
 
-	downloadJson() {
-		const formattedJson = this.outputArea.value;
-		if (formattedJson) {
-			const blob = new Blob([formattedJson], { type: "application/json" });
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement("a");
-			a.href = url;
-			a.download = "formatted.json";
-			a.click();
-			URL.revokeObjectURL(url);
-		} else {
-			alert("There is no formatted JSON to download.");
-		}
-	}
-
+  downloadJson() {
+    const formattedJson = this.outputArea.value;
+    if (formattedJson) {
+      const blob = new Blob([formattedJson], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "formatted.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    } else {
+      alert("There is no formatted JSON to download.");
+    }
+  }
 }
 
 // Register the custom element

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -54,22 +54,27 @@ class JsonFormatterTool extends HTMLElement {
 		this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
 	}
 
-	/**
-	 * Formats the input JSON and updates the output area.
-	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-	 */
-	formatJson = () => {
-		try {
-			const input = this.inputArea.value;
-			if (input) {
-				const parsed = JSON.parse(input);
-				this.outputArea.value = JSON.stringify(parsed, null, 2);
-			}
-		} catch (error) {
-			this.outputArea.value = `Error: ${error.message}`;
-		}
-	};
+  /**
+   * Formats the input JSON and updates the output area.
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+   */
+  formatJson = () => {
+    try {
+      const input = this.inputArea.value;
+      if (input) {
+        const parsed = JSON.parse(input);
+        this.outputArea.value = JSON.stringify(parsed, null, 2);
+        this.copyBtn.disabled = false;
+        this.downloadBtn.disabled = false;
+      }
+    } catch (error) {
+      this.outputArea.value = `Error: ${error.message}`;
+      // Disable the buttons if JSON is invalid
+      this.copyBtn.disabled = true;
+      this.downloadBtn.disabled = true;
+    }
+  };
 
 	/**
 	 * Cleans up event listeners when the element is removed from the DOM.

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -11,7 +11,6 @@ class JsonFormatterTool extends HTMLElement {
     this.outputArea = null;
     this.copyBtn = null;
     this.downloadBtn = null;
-    this.uploadBtn = null;
     this.copyNotification = null;
     this.downloadNotification = null;
   }
@@ -115,8 +114,6 @@ class JsonFormatterTool extends HTMLElement {
       this.copyBtn.removeEventListener("click", this.copyToClipboard);
     if (this.downloadBtn)
       this.downloadBtn.removeEventListener("click", this.downloadJson);
-    if (this.uploadBtn)
-      this.uploadBtn.removeEventListener("change", this.handleFileUpload);
   }
 
   /**
@@ -131,12 +128,6 @@ class JsonFormatterTool extends HTMLElement {
         .then(() =>
           this.showNotification(this.copyNotification, "Copied to clipboard!"),
         )
-        .catch(() =>
-          this.showNotification(
-            this.copyNotification,
-            "Failed to copy to clipboard",
-          ),
-        );
     } else {
       this.showNotification(this.copyNotification, "Nothing to copy!");
     }

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -1,29 +1,29 @@
 class JsonFormatterTool extends HTMLElement {
-  /**
-   * Initializes a new instance of JsonFormatterTool.
-   * Sets up initial properties for toolPanel, formatBtn, inputArea, and outputArea as null.
-   */
-  constructor() {
-    super();
-    this.toolPanel = null;
-    this.formatBtn = null;
-    this.inputArea = null;
-    this.outputArea = null;
-    this.copyBtn = null;
-    this.downloadBtn = null;
-    this.uploadBtn = null;
-  }
+	/**
+	 * Initializes a new instance of JsonFormatterTool.
+	 * Sets up initial properties for toolPanel, formatBtn, inputArea, and outputArea as null.
+	 */
+	constructor() {
+		super();
+		this.toolPanel = null;
+		this.formatBtn = null;
+		this.inputArea = null;
+		this.outputArea = null;
+		this.copyBtn = null;
+		this.downloadBtn = null;
+		this.uploadBtn = null;
+	}
 
-  /**
-   * Called when the element is added to the DOM.
-   * Sets up the HTML structure of the tool and stores references to elements.
-   * Binds event listeners for the "Format" button.
-   */
-  connectedCallback() {
-    // Set up the HTML structure when the element is added to the DOM
-    this.innerHTML = `
-      <link rel="stylesheet" href="json-formatter/json-formatter-tool.css"> 
-      <section class="tool-panel">
+	/**
+	 * Called when the element is added to the DOM.
+	 * Sets up the HTML structure of the tool and stores references to elements.
+	 * Binds event listeners for the "Format" button.
+	 */
+	connectedCallback() {
+		// Set up the HTML structure when the element is added to the DOM
+		this.innerHTML = `
+      <link rel="stylesheet" href="json-formatter/json-formatter-tool.css" > 
+      <section class="tool-panel" style="display:none;">
         <header class="tool-header">
           <h3>JSON Formatter</h3>
         </header>
@@ -40,78 +40,78 @@ class JsonFormatterTool extends HTMLElement {
       </section>
       `;
 
-    // Store references to elements
-    this.toolPanel = this.querySelector(".tool-panel");
-    this.formatBtn = this.querySelector(".format-btn");
-    this.inputArea = this.querySelector(".input-area");
-    this.outputArea = this.querySelector(".output-area");
-    this.copyBtn = this.querySelector(".copy-btn");
-    this.downloadBtn = this.querySelector(".download-btn");
+		// Store references to elements
+		this.toolPanel = this.querySelector(".tool-panel");
+		this.formatBtn = this.querySelector(".format-btn");
+		this.inputArea = this.querySelector(".input-area");
+		this.outputArea = this.querySelector(".output-area");
+		this.copyBtn = this.querySelector(".copy-btn");
+		this.downloadBtn = this.querySelector(".download-btn");
 
-    // Bind event listeners
-    this.formatBtn.addEventListener("click", this.formatJson);
-    this.copyBtn.addEventListener("click", this.copyToClipboard.bind(this));
-    this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
-  }
+		// Bind event listeners
+		this.formatBtn.addEventListener("click", this.formatJson);
+		this.copyBtn.addEventListener("click", this.copyToClipboard.bind(this));
+		this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
+	}
 
-  /**
-   * Formats the input JSON and updates the output area.
-   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-   */
-  formatJson = () => {
-    try {
-      const input = this.inputArea.value;
-      if (input) {
-        const parsed = JSON.parse(input);
-        this.outputArea.value = JSON.stringify(parsed, null, 2);
-      }
-    } catch (error) {
-      this.outputArea.value = `Error: ${error.message}`;
-    }
-  };
+	/**
+	 * Formats the input JSON and updates the output area.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+	 */
+	formatJson = () => {
+		try {
+			const input = this.inputArea.value;
+			if (input) {
+				const parsed = JSON.parse(input);
+				this.outputArea.value = JSON.stringify(parsed, null, 2);
+			}
+		} catch (error) {
+			this.outputArea.value = `Error: ${error.message}`;
+		}
+	};
 
-  /**
-   * Cleans up event listeners when the element is removed from the DOM.
-   * @see https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks
-   */
-  disconnectedCallback() {
-    // Clean up event listeners when the element is removed from the DOM
-    if (this.formatBtn)
-      this.formatBtn.removeEventListener("click", this.formatJson);
-    if (this.copyBtn)
-      this.copyBtn.removeEventListener("click", this.copyToClipboard);
-    if (this.downloadBtn)
-      this.downloadBtn.removeEventListener("click", this.downloadJson);
-    if (this.uploadBtn)
-      this.uploadBtn.removeEventListener("change", this.handleFileUpload);
-  }
-  copyToClipboard() {
-    const output = this.outputArea.value;
-    if (output) {
-      navigator.clipboard
-        .writeText(output)
-        .then(() => alert("Formatted JSON copied to clipboard!"))
-        .catch(() => alert("Failed to copy JSON to clipboard."));
-    } else {
-      alert("Nothing to copy!");
-    }
-  }
+	/**
+	 * Cleans up event listeners when the element is removed from the DOM.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks
+	 */
+	disconnectedCallback() {
+		// Clean up event listeners when the element is removed from the DOM
+		if (this.formatBtn)
+			this.formatBtn.removeEventListener("click", this.formatJson);
+		if (this.copyBtn)
+			this.copyBtn.removeEventListener("click", this.copyToClipboard);
+		if (this.downloadBtn)
+			this.downloadBtn.removeEventListener("click", this.downloadJson);
+		if (this.uploadBtn)
+			this.uploadBtn.removeEventListener("change", this.handleFileUpload);
+	}
+	copyToClipboard() {
+		const output = this.outputArea.value;
+		if (output) {
+			navigator.clipboard
+				.writeText(output)
+				.then(() => alert("Formatted JSON copied to clipboard!"))
+				.catch(() => alert("Failed to copy JSON to clipboard."));
+		} else {
+			alert("Nothing to copy!");
+		}
+	}
 
-  downloadJson() {
-    const formattedJson = this.outputArea.value;
-    if (formattedJson) {
-      const blob = new Blob([formattedJson], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "formatted.json";
-      a.click();
-      URL.revokeObjectURL(url);
-    } else {
-      alert("There is no formatted JSON to download.");
-    }
-  }
+	downloadJson() {
+		const formattedJson = this.outputArea.value;
+		if (formattedJson) {
+			const blob = new Blob([formattedJson], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = "formatted.json";
+			a.click();
+			URL.revokeObjectURL(url);
+		} else {
+			alert("There is no formatted JSON to download.");
+		}
+	}
 }
 
 // Register the custom element

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -127,7 +127,7 @@ class JsonFormatterTool extends HTMLElement {
         .writeText(output)
         .then(() =>
           this.showNotification(this.copyNotification, "Copied to clipboard!"),
-        )
+        );
     } else {
       this.showNotification(this.copyNotification, "Nothing to copy!");
     }

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -29,7 +29,6 @@ class JsonFormatterTool extends HTMLElement {
         </header>
         <hr />
         <section class="tool-content">
-          <input type="file" class="upload-btn" accept=".json" aria-label="Upload JSON File" />
           <textarea class="input-area" placeholder="Paste your JSON here"></textarea>
           <button class="format-btn">Format</button>
           <textarea class="output-area" readonly></textarea>
@@ -48,13 +47,11 @@ class JsonFormatterTool extends HTMLElement {
     this.outputArea = this.querySelector(".output-area");
     this.copyBtn = this.querySelector(".copy-btn");
     this.downloadBtn = this.querySelector(".download-btn");
-    this.uploadBtn = this.querySelector(".upload-btn");
 
     // Bind event listeners
     this.formatBtn.addEventListener("click", this.formatJson);
     this.copyBtn.addEventListener("click", this.copyToClipboard.bind(this));
     this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
-    this.uploadBtn.addEventListener("change", this.handleFileUpload.bind(this));
   }
 
   /**
@@ -98,24 +95,6 @@ class JsonFormatterTool extends HTMLElement {
         .catch(() => alert("Failed to copy JSON to clipboard."));
     } else {
       alert("Nothing to copy!");
-    }
-  }
-
-  handleFileUpload(event) {
-    const file = event.target.files[0];
-    if (file && file.type === "application/json") {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const jsonContent = JSON.parse(e.target.result);
-          this.inputArea.value = JSON.stringify(jsonContent, null, 2);
-        } catch (error) {
-          this.inputArea.value = `Error reading file: ${error.message}`;
-        }
-      };
-      reader.readAsText(file);
-    } else {
-      alert("Please upload a valid JSON file.");
     }
   }
 

--- a/src/json-formatter/json-formatter-tool.js
+++ b/src/json-formatter/json-formatter-tool.js
@@ -12,6 +12,8 @@ class JsonFormatterTool extends HTMLElement {
     this.copyBtn = null;
     this.downloadBtn = null;
     this.uploadBtn = null;
+    this.copyNotification = null;
+    this.downloadNotification = null;
   }
 
   /**
@@ -32,8 +34,18 @@ class JsonFormatterTool extends HTMLElement {
           <button class="format-btn">Format</button>
           <textarea class="output-area" readonly></textarea>
           <div align="center" class="button-group">
-            <button class="copy-btn">Copy to Clipboard</button>
-            <button class="download-btn">Download Formatted JSON</button>
+            <div class="copy-btn-container">
+              <div class="notification-wrapper">
+                <div class="notification">Copied to clipboard!</div>
+              </div>
+              <button class="copy-btn">Copy to Clipboard</button>
+            </div>
+            <div class="download-btn-container">
+              <div class="notification-wrapper">
+                <div class="notification">Downloaded file!</div>
+              </div>
+              <button class="download-btn">Download JSON File</button>
+            </div>
           </div> 
         </section>
       </section>
@@ -46,11 +58,27 @@ class JsonFormatterTool extends HTMLElement {
     this.outputArea = this.querySelector(".output-area");
     this.copyBtn = this.querySelector(".copy-btn");
     this.downloadBtn = this.querySelector(".download-btn");
+    this.copyNotification = this.querySelector(
+      ".copy-btn-container .notification",
+    );
+    this.downloadNotification = this.querySelector(
+      ".download-btn-container .notification",
+    );
 
     // Bind event listeners
     this.formatBtn.addEventListener("click", this.formatJson);
     this.copyBtn.addEventListener("click", this.copyToClipboard.bind(this));
     this.downloadBtn.addEventListener("click", this.downloadJson.bind(this));
+  }
+
+  showNotification(notification, message) {
+    notification.textContent = message;
+    notification.classList.add("show");
+
+    // Hide notification after 2 seconds
+    setTimeout(() => {
+      notification.classList.remove("show");
+    }, 1000);
   }
 
   /**
@@ -90,18 +118,34 @@ class JsonFormatterTool extends HTMLElement {
     if (this.uploadBtn)
       this.uploadBtn.removeEventListener("change", this.handleFileUpload);
   }
+
+  /**
+   * The `copyToClipboard` function copies the content of an output area to the clipboard and displays
+   * a notification based on the outcome.
+   */
   copyToClipboard() {
     const output = this.outputArea.value;
     if (output) {
       navigator.clipboard
         .writeText(output)
-        .then(() => alert("Formatted JSON copied to clipboard!"))
-        .catch(() => alert("Failed to copy JSON to clipboard."));
+        .then(() =>
+          this.showNotification(this.copyNotification, "Copied to clipboard!"),
+        )
+        .catch(() =>
+          this.showNotification(
+            this.copyNotification,
+            "Failed to copy to clipboard",
+          ),
+        );
     } else {
-      alert("Nothing to copy!");
+      this.showNotification(this.copyNotification, "Nothing to copy!");
     }
   }
 
+  /**
+   * The `downloadJson` function downloads a JSON file with formatted content if available, and
+   * displays a notification accordingly.
+   */
   downloadJson() {
     const formattedJson = this.outputArea.value;
     if (formattedJson) {
@@ -112,8 +156,9 @@ class JsonFormatterTool extends HTMLElement {
       a.download = "formatted.json";
       a.click();
       URL.revokeObjectURL(url);
+      this.showNotification(this.downloadNotification, "JSON file downloaded!");
     } else {
-      alert("There is no formatted JSON to download.");
+      this.showNotification(this.downloadNotification, "No JSON to download!");
     }
   }
 }

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -7,7 +7,6 @@ describe("JsonFormatterTool", () => {
   let formatBtn;
   let copyBtn;
   let downloadBtn;
-  let uploadBtn;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -21,7 +20,6 @@ describe("JsonFormatterTool", () => {
     formatBtn = jsonFormatterTool.querySelector(".format-btn");
     copyBtn = jsonFormatterTool.querySelector(".copy-btn");
     downloadBtn = jsonFormatterTool.querySelector(".download-btn");
-    uploadBtn = jsonFormatterTool.querySelector(".upload-btn");
   });
 
   // tool render test
@@ -31,7 +29,6 @@ describe("JsonFormatterTool", () => {
     expect(outputArea).toBeTruthy();
     expect(copyBtn).toBeTruthy();
     expect(downloadBtn).toBeTruthy();
-    expect(uploadBtn).toBeTruthy();
   });
 
   // simple JSON formatting test
@@ -134,6 +131,7 @@ describe("JsonFormatterTool", () => {
     expect(mockAnchor.click).toHaveBeenCalled();
     expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
     expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
   });
 
   // empty output download alert test

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -39,7 +39,7 @@ describe("JsonFormatterTool", () => {
 
     // Check that the output area contains formatted JSON
     expect(outputArea.value).toBe(
-      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}'
+      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}',
     );
   });
 
@@ -50,7 +50,7 @@ describe("JsonFormatterTool", () => {
     formatBtn.click();
 
     expect(outputArea.value).toBe(
-      '{\n  "id": 12345,\n  "name": "John Doe",\n  "email": "johndoe@example.com",\n  "address": {\n    "street": "123 Main St",\n    "city": "Somewhere",\n    "zipcode": 12345\n  },\n  "phones": [\n    {\n      "type": "mobile",\n      "number": "123-456-7890"\n    },\n    {\n      "type": "home",\n      "number": "098-765-4321"\n    }\n  ],\n  "preferences": {\n    "contactMethod": "email",\n    "newsletter": true\n  }\n}'
+      '{\n  "id": 12345,\n  "name": "John Doe",\n  "email": "johndoe@example.com",\n  "address": {\n    "street": "123 Main St",\n    "city": "Somewhere",\n    "zipcode": 12345\n  },\n  "phones": [\n    {\n      "type": "mobile",\n      "number": "123-456-7890"\n    },\n    {\n      "type": "home",\n      "number": "098-765-4321"\n    }\n  ],\n  "preferences": {\n    "contactMethod": "email",\n    "newsletter": true\n  }\n}',
     );
   });
 
@@ -88,11 +88,12 @@ describe("JsonFormatterTool", () => {
     outputArea.value = '{\n  "name": "Dylan Lukes",\n  "age": 30\n}';
     await copyBtn.click();
     expect(clipboardMock).toHaveBeenCalledWith(
-      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}'
+      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}',
     );
-    expect(alertMock).toHaveBeenCalledWith("Formatted JSON copied to clipboard!");
+    expect(alertMock).toHaveBeenCalledWith(
+      "Formatted JSON copied to clipboard!",
+    );
   });
-
 
   // empty output copy alert test
   test("should alert when copying with no formatted JSON", () => {
@@ -131,7 +132,6 @@ describe("JsonFormatterTool", () => {
     expect(mockAnchor.click).toHaveBeenCalled();
     expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
     expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
-
   });
 
   // empty output download alert test
@@ -140,7 +140,7 @@ describe("JsonFormatterTool", () => {
     outputArea.value = "";
     downloadBtn.click();
     expect(alertMock).toHaveBeenCalledWith(
-      "There is no formatted JSON to download."
+      "There is no formatted JSON to download.",
     );
   });
 
@@ -150,7 +150,7 @@ describe("JsonFormatterTool", () => {
     jsonFormatterTool.remove();
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "click",
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 });

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -24,6 +24,7 @@ describe("JsonFormatterTool", () => {
     uploadBtn = jsonFormatterTool.querySelector(".upload-btn");
   });
 
+  // tool render test
   test("Should render the JSON formatter tool correctly", () => {
     expect(inputArea).toBeTruthy();
     expect(formatBtn).toBeTruthy();
@@ -33,6 +34,7 @@ describe("JsonFormatterTool", () => {
     expect(uploadBtn).toBeTruthy();
   });
 
+  // simple JSON formatting test
   test("should format JSON correctly when valid JSON is entered", () => {
     // Input valid JSON and trigger the format button
     inputArea.value = '{"name": "Dylan Lukes", "age": 30}';
@@ -44,6 +46,17 @@ describe("JsonFormatterTool", () => {
     );
   });
 
+  // complex JSON formatting test
+  test("should format JSON correctly when valid JSON is entered", () => {
+    inputArea.value = '{ "id":12345,"name":"John Doe", "email": "johndoe@example.com" , "address" : { "street":"123 Main St","city": "Somewhere" , "zipcode":12345} ,"phones" :[ { "type" : "mobile","number" :"123-456-7890" },{ "type": "home" , "number":"098-765-4321"} ], "preferences" : {"contactMethod" :"email", "newsletter":true}}';
+    formatBtn.click();
+
+    expect(outputArea.value).toBe(
+      '{\n  \"id\": 12345,\n  \"name\": \"John Doe\",\n  \"email\": \"johndoe@example.com\",\n  \"address\": {\n    \"street\": \"123 Main St\",\n    \"city\": \"Somewhere\",\n    \"zipcode\": 12345\n  },\n  \"phones\": [\n    {\n      \"type\": \"mobile\",\n      \"number\": \"123-456-7890\"\n    },\n    {\n      \"type\": \"home\",\n      \"number\": \"098-765-4321\"\n    }\n  ],\n  \"preferences\": {\n    \"contactMethod\": \"email\",\n    \"newsletter\": true\n  }\n}'
+    );
+  });
+
+  // empty input test
   test("should stay empty on empty input", () => {
     inputArea = "";
     formatBtn.click();
@@ -52,6 +65,7 @@ describe("JsonFormatterTool", () => {
     expect(outputArea.value).toBe("");
   });
 
+  // invalid JSON error test
   test("should indicate error on invalid JSON", () => {
     inputArea.value = '{"name": "Dylan Lukes", "age": 30';
     formatBtn.click();
@@ -60,6 +74,7 @@ describe("JsonFormatterTool", () => {
     expect(outputArea.value).toMatch(/Error/);
   });
 
+  // empty output copy alert test
   test("should alert when copying with no formatted JSON", () => {
     const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     outputArea.value = "";
@@ -67,6 +82,7 @@ describe("JsonFormatterTool", () => {
     expect(alertMock).toHaveBeenCalledWith("Nothing to copy!");
   });
 
+  // empty output download alert test
   test("Should alert if trying to download without formatted JSON", () => {
     const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     outputArea.value = "";
@@ -76,6 +92,7 @@ describe("JsonFormatterTool", () => {
     );
   });
 
+  // JS cleanup on close test
   test("Should handle cleanup correctly when disconnected", () => {
     const removeEventListenerSpy = jest.spyOn(formatBtn, "removeEventListener");
     jsonFormatterTool.remove();

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -181,5 +181,4 @@ describe("JsonFormatterTool", () => {
     expect(copyBtn.disabled).toBe(false);
     expect(downloadBtn.disabled).toBe(false);
   });
-
 });

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -42,17 +42,18 @@ describe("JsonFormatterTool", () => {
 
     // Check that the output area contains formatted JSON
     expect(outputArea.value).toBe(
-      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}',
+      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}'
     );
   });
 
   // complex JSON formatting test
   test("should format JSON correctly when valid JSON is entered", () => {
-    inputArea.value = '{ "id":12345,"name":"John Doe", "email": "johndoe@example.com" , "address" : { "street":"123 Main St","city": "Somewhere" , "zipcode":12345} ,"phones" :[ { "type" : "mobile","number" :"123-456-7890" },{ "type": "home" , "number":"098-765-4321"} ], "preferences" : {"contactMethod" :"email", "newsletter":true}}';
+    inputArea.value =
+      '{ "id":12345,"name":"John Doe", "email": "johndoe@example.com" , "address" : { "street":"123 Main St","city": "Somewhere" , "zipcode":12345} ,"phones" :[ { "type" : "mobile","number" :"123-456-7890" },{ "type": "home" , "number":"098-765-4321"} ], "preferences" : {"contactMethod" :"email", "newsletter":true}}';
     formatBtn.click();
 
     expect(outputArea.value).toBe(
-      '{\n  \"id\": 12345,\n  \"name\": \"John Doe\",\n  \"email\": \"johndoe@example.com\",\n  \"address\": {\n    \"street\": \"123 Main St\",\n    \"city\": \"Somewhere\",\n    \"zipcode\": 12345\n  },\n  \"phones\": [\n    {\n      \"type\": \"mobile\",\n      \"number\": \"123-456-7890\"\n    },\n    {\n      \"type\": \"home\",\n      \"number\": \"098-765-4321\"\n    }\n  ],\n  \"preferences\": {\n    \"contactMethod\": \"email\",\n    \"newsletter\": true\n  }\n}'
+      '{\n  "id": 12345,\n  "name": "John Doe",\n  "email": "johndoe@example.com",\n  "address": {\n    "street": "123 Main St",\n    "city": "Somewhere",\n    "zipcode": 12345\n  },\n  "phones": [\n    {\n      "type": "mobile",\n      "number": "123-456-7890"\n    },\n    {\n      "type": "home",\n      "number": "098-765-4321"\n    }\n  ],\n  "preferences": {\n    "contactMethod": "email",\n    "newsletter": true\n  }\n}'
     );
   });
 
@@ -74,6 +75,28 @@ describe("JsonFormatterTool", () => {
     expect(outputArea.value).toMatch(/Error/);
   });
 
+  // successful copy button test
+  test("should alert a successful copy of formatted JSON", async () => {
+    // Make the test async
+    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+
+    // Successful copy to clipboard
+    const clipboardMock = jest.fn().mockResolvedValue();
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: clipboardMock,
+      },
+      writable: true,
+    });
+    outputArea.value = '{\n  "name": "Dylan Lukes",\n  "age": 30\n}';
+    await copyBtn.click();
+    expect(clipboardMock).toHaveBeenCalledWith(
+      '{\n  "name": "Dylan Lukes",\n  "age": 30\n}'
+    );
+    expect(alertMock).toHaveBeenCalledWith("Formatted JSON copied to clipboard!");
+  });
+
+
   // empty output copy alert test
   test("should alert when copying with no formatted JSON", () => {
     const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
@@ -82,13 +105,44 @@ describe("JsonFormatterTool", () => {
     expect(alertMock).toHaveBeenCalledWith("Nothing to copy!");
   });
 
+  // successful file download test
+  test("should trigger file download when formatted JSON exists", () => {
+    // Mock the creation of anchor element
+    const mockAnchor = {
+      click: jest.fn(),
+      href: "",
+      download: "",
+    };
+
+    const createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation(() => mockAnchor);
+
+    // Mock URL.createObjectURL and revokeObjectURL
+    const mockCreateObjectURL = jest.fn().mockReturnValue("blob:mock-url");
+    const mockRevokeObjectURL = jest.fn();
+    global.URL.createObjectURL = mockCreateObjectURL;
+    global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    // Set up test data
+    outputArea.value = '{"name": "John"}';
+    downloadBtn.click();
+
+    // Assertions
+    expect(createElementSpy).toHaveBeenCalledWith("a");
+    expect(mockAnchor.download).toBe("formatted.json");
+    expect(mockAnchor.click).toHaveBeenCalled();
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
   // empty output download alert test
   test("Should alert if trying to download without formatted JSON", () => {
     const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     outputArea.value = "";
     downloadBtn.click();
     expect(alertMock).toHaveBeenCalledWith(
-      "There is no formatted JSON to download.",
+      "There is no formatted JSON to download."
     );
   });
 
@@ -98,7 +152,7 @@ describe("JsonFormatterTool", () => {
     jsonFormatterTool.remove();
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "click",
-      expect.any(Function),
+      expect.any(Function)
     );
   });
 });

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -7,6 +7,8 @@ describe("JsonFormatterTool", () => {
   let formatBtn;
   let copyBtn;
   let downloadBtn;
+  let copyNotification;
+  let downloadNotification;
 
   beforeEach(() => {
     document.body.innerHTML = `

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -5,6 +5,9 @@ describe("JsonFormatterTool", () => {
   let inputArea;
   let outputArea;
   let formatBtn;
+  let copyBtn;
+  let downloadBtn;
+  let uploadBtn;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -16,12 +19,18 @@ describe("JsonFormatterTool", () => {
     inputArea = jsonFormatterTool.querySelector(".input-area");
     outputArea = jsonFormatterTool.querySelector(".output-area");
     formatBtn = jsonFormatterTool.querySelector(".format-btn");
+    copyBtn = jsonFormatterTool.querySelector(".copy-btn");
+    downloadBtn = jsonFormatterTool.querySelector(".download-btn");
+    uploadBtn = jsonFormatterTool.querySelector(".upload-btn");
   });
 
   test("Should render the JSON formatter tool correctly", () => {
     expect(inputArea).toBeTruthy();
     expect(formatBtn).toBeTruthy();
     expect(outputArea).toBeTruthy();
+    expect(copyBtn).toBeTruthy();
+    expect(downloadBtn).toBeTruthy();
+    expect(uploadBtn).toBeTruthy();
   });
 
   test("should format JSON correctly when valid JSON is entered", () => {
@@ -35,7 +44,7 @@ describe("JsonFormatterTool", () => {
     );
   });
 
-  test("should error out when input is empty", () => {
+  test("should stay empty on empty input", () => {
     inputArea = "";
     formatBtn.click();
 
@@ -49,5 +58,30 @@ describe("JsonFormatterTool", () => {
 
     // Check that the output area shows the error
     expect(outputArea.value).toMatch(/Error/);
+  });
+
+  test("should alert when copying with no formatted JSON", () => {
+    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+    outputArea.value = "";
+    copyBtn.click();
+    expect(alertMock).toHaveBeenCalledWith("Nothing to copy!");
+  });
+
+  test("Should alert if trying to download without formatted JSON", () => {
+    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+    outputArea.value = "";
+    downloadBtn.click();
+    expect(alertMock).toHaveBeenCalledWith(
+      "There is no formatted JSON to download.",
+    );
+  });
+
+  test("Should handle cleanup correctly when disconnected", () => {
+    const removeEventListenerSpy = jest.spyOn(formatBtn, "removeEventListener");
+    jsonFormatterTool.remove();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+    );
   });
 });

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -20,6 +20,12 @@ describe("JsonFormatterTool", () => {
     formatBtn = jsonFormatterTool.querySelector(".format-btn");
     copyBtn = jsonFormatterTool.querySelector(".copy-btn");
     downloadBtn = jsonFormatterTool.querySelector(".download-btn");
+    copyNotification = jsonFormatterTool.querySelector(
+      ".copy-btn-container .notification",
+    );
+    downloadNotification = jsonFormatterTool.querySelector(
+      ".download-btn-container .notification",
+    );
   });
 
   // tool render test
@@ -29,6 +35,8 @@ describe("JsonFormatterTool", () => {
     expect(outputArea).toBeTruthy();
     expect(copyBtn).toBeTruthy();
     expect(downloadBtn).toBeTruthy();
+    expect(copyNotification).toBeTruthy();
+    expect(downloadNotification).toBeTruthy();
   });
 
   // simple JSON formatting test
@@ -75,7 +83,9 @@ describe("JsonFormatterTool", () => {
   // successful copy button test
   test("should alert a successful copy of formatted JSON", async () => {
     // Make the test async
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+    const showNotificationMock = jest
+      .spyOn(jsonFormatterTool, "showNotification")
+      .mockImplementation(() => {});
 
     // Successful copy to clipboard
     const clipboardMock = jest.fn().mockResolvedValue();
@@ -90,17 +100,26 @@ describe("JsonFormatterTool", () => {
     expect(clipboardMock).toHaveBeenCalledWith(
       '{\n  "name": "Dylan Lukes",\n  "age": 30\n}',
     );
-    expect(alertMock).toHaveBeenCalledWith(
-      "Formatted JSON copied to clipboard!",
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      jsonFormatterTool.copyNotification,
+      "Copied to clipboard!",
     );
   });
 
   // empty output copy alert test
   test("should alert when copying with no formatted JSON", () => {
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+    // Mock the showNotification method
+    const showNotificationMock = jest
+      .spyOn(jsonFormatterTool, "showNotification")
+      .mockImplementation(() => {});
     outputArea.value = "";
     copyBtn.click();
-    expect(alertMock).toHaveBeenCalledWith("Nothing to copy!");
+
+    // Assert that showNotification was called with the correct arguments
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      jsonFormatterTool.copyNotification,
+      "Nothing to copy!",
+    );
   });
 
   // successful file download test
@@ -136,11 +155,14 @@ describe("JsonFormatterTool", () => {
 
   // empty output download alert test
   test("Should alert if trying to download without formatted JSON", () => {
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+    const showNotificationMock = jest
+      .spyOn(jsonFormatterTool, "showNotification")
+      .mockImplementation(() => {});
     outputArea.value = "";
     downloadBtn.click();
-    expect(alertMock).toHaveBeenCalledWith(
-      "There is no formatted JSON to download.",
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      jsonFormatterTool.downloadNotification,
+      "No JSON to download!",
     );
   });
 

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -44,7 +44,7 @@ describe("JsonFormatterTool", () => {
   });
 
   // complex JSON formatting test
-  test("should format JSON correctly when valid JSON is entered", () => {
+  test("should format a more complex json input correctly when valid JSON is entered", () => {
     inputArea.value =
       '{ "id":12345,"name":"John Doe", "email": "johndoe@example.com" , "address" : { "street":"123 Main St","city": "Somewhere" , "zipcode":12345} ,"phones" :[ { "type" : "mobile","number" :"123-456-7890" },{ "type": "home" , "number":"098-765-4321"} ], "preferences" : {"contactMethod" :"email", "newsletter":true}}';
     formatBtn.click();

--- a/src/json-formatter/json-formatter-tool.test.js
+++ b/src/json-formatter/json-formatter-tool.test.js
@@ -153,4 +153,31 @@ describe("JsonFormatterTool", () => {
       expect.any(Function),
     );
   });
+  test("Should disable the copy and download buttons on error", () => {
+    inputArea.value = '{"name": "Dylan Lukes", "age": 30';
+    formatBtn.click();
+    // Check that the output area shows the error
+    expect(outputArea.value).toMatch(/Error/);
+
+    // Check that the copy and download buttons are disabled
+    expect(copyBtn.disabled).toBe(true);
+    expect(downloadBtn.disabled).toBe(true);
+  });
+
+  test("Should enable the copy and download buttons after error when valid input is formatted", () => {
+    inputArea.value = '{"name": "Dylan Lukes", "age": 30';
+    formatBtn.click();
+    // Check that the output area shows the error
+    expect(outputArea.value).toMatch(/Error/);
+
+    // Check that the copy and download buttons are disabled
+    expect(copyBtn.disabled).toBe(true);
+    expect(downloadBtn.disabled).toBe(true);
+
+    // Check that the copy and download buttons are enabled
+    inputArea.value = '{\n  "name": "Dylan Lukes",\n  "age": 30\n}';
+    formatBtn.click();
+    expect(copyBtn.disabled).toBe(false);
+    expect(downloadBtn.disabled).toBe(false);
+  });
 });

--- a/src/jwt-generator/jwt-generator-tool.css
+++ b/src/jwt-generator/jwt-generator-tool.css
@@ -36,7 +36,7 @@
   padding: 20px;
   background-color: var(--tool-bg-color);
   color: var(--inverse-color);
-  gap: 20px
+  gap: 20px;
 }
 
 /* Input and output text areas */


### PR DESCRIPTION
## Description

Updated so that CSS is rendered before the HTML, preventing HTML from showing first. Additional test cases added too.

## Related Issue

- Works on #[82]

## Checklist

- [x] Code compiles without errors.
- [x] All tests pass.
- [x] Documentation has been updated as necessary.