### PR TITLE
Recent edits to unix time stamp converter, css loads before html, new tests, iso format support

### DIFF
--- a/src/jwt-generator/jwt-generator-tool.css
+++ b/src/jwt-generator/jwt-generator-tool.css
@@ -36,7 +36,7 @@
   padding: 20px;
   background-color: var(--tool-bg-color);
   color: var(--inverse-color);
-  gap: 20px
+  gap: 20px;
 }
 
 /* Input and output text areas */

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.css
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.css
@@ -52,7 +52,7 @@
 }
 
 /* Format button styling */
-.convert-btn {
+.convert-utc-btn {
   align-self: center;
   padding: 10px 20px;
   background-color: #061524;
@@ -66,9 +66,34 @@
     transform 0.2s ease;
 }
 
-.convert-btn:hover {
+.convert-utc-btn:hover {
   background-color: #34495e;
   transform: scale(1.05);
+}
+
+.convert-iso-btn {
+  align-self: center;
+  padding: 10px 20px;
+  background-color: #061524;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(var(--font-size-desktop) * 1);
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
+}
+
+.convert-iso-btn:hover {
+  background-color: #34495e;
+  transform: scale(1.05);
+}
+
+.button-group {
+  display: flex;
+  justify-content: center;
+  gap: 15px; /* Adds space between buttons */
 }
 
 @media (max-width: 600px) {
@@ -78,5 +103,12 @@
 
   .tool-header {
     font-size: var(--font-size-mobile); /* Mobile font size */
+  }
+
+  .button-group {
+    flex-direction: column;
+    /* Stack buttons vertically on smaller screens */
+    gap: 10px;
+    /* Adjust spacing for mobile view */
   }
 }

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.css
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.css
@@ -1,14 +1,15 @@
 .tool-panel {
-	display: flex !important;
-	flex: 1;
-	width: 100%;
-	margin: 20px auto;
-	background: var(--bg-color);
-	border-radius: 8px;
-	box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-	z-index: 1000;
-	overflow: auto;
-	flex-direction: column;
+  display: flex !important;
+  flex: 1;
+  width: 100%;
+  margin: 20px auto;
+  background: var(--bg-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  overflow: auto;
+  flex-direction: column;
+}
 
 /* Header styling */
 .tool-header {
@@ -56,37 +57,37 @@
 
 /* Format button styling */
 .convert-utc-btn {
-	align-self: center;
-	padding: 10px 20px;
-	background-color: var(--button-bg);
-	color: var(--button-text-color);
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: calc(var(--font-size-desktop) * 1);
-	transition:
-		background-color 0.3s ease,
-		transform 0.2s ease;
+  align-self: center;
+  padding: 10px 20px;
+  background-color: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(var(--font-size-desktop) * 1);
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 }
 
 .convert-utc-btn:hover {
   background-color: var(--button-hover-bg);
   color: var(--inverse-color);
   transform: scale(1.05);
-  }
+}
 
 .convert-iso-btn {
-	align-self: center;
-	padding: 10px 20px;
-	background-color: var(--button-bg);
-	color: var(--button-text-color);
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: calc(var(--font-size-desktop) * 1);
-	transition:
-		background-color 0.3s ease,
-		transform 0.2s ease;
+  align-self: center;
+  padding: 10px 20px;
+  background-color: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: calc(var(--font-size-desktop) * 1);
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 }
 
 .convert-iso-btn:hover {
@@ -96,9 +97,9 @@
 }
 
 .button-group {
-	display: flex;
-	justify-content: center;
-	gap: 15px; /* Adds space between buttons */
+  display: flex;
+  justify-content: center;
+  gap: 15px; /* Adds space between buttons */
 }
 
 .convert-iso-btn {
@@ -132,13 +133,13 @@ textarea::placeholder {
 }
 
 @media (max-width: 600px) {
-	.tool-panel {
-		font-size: var(--font-size-mobile); /* Mobile font size */
-	}
+  .tool-panel {
+    font-size: var(--font-size-mobile); /* Mobile font size */
+  }
 
-	.tool-header {
-		font-size: var(--font-size-mobile); /* Mobile font size */
-	}
+  .tool-header {
+    font-size: var(--font-size-mobile); /* Mobile font size */
+  }
 
   .tool-header {
     font-size: var(--font-size-mobile); /* Mobile font size */

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.css
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.css
@@ -1,114 +1,114 @@
 .tool-panel {
-  display: flex;
-  flex: 1;
-  width: 100%;
-  margin: 20px auto;
-  background: #ffffff;
-  border-radius: 8px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-  z-index: 1000;
-  overflow: auto;
-  flex-direction: column;
+	display: flex !important;
+	flex: 1;
+	width: 100%;
+	margin: 20px auto;
+	background: #ffffff;
+	border-radius: 8px;
+	box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+	z-index: 1000;
+	overflow: auto;
+	flex-direction: column;
 }
 
 /* Header styling */
 .tool-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 15px;
-  background-color: #061524;
-  color: #ffffff;
-  font-size: calc(var(--font-size-desktop) * 1.2);
-  font-weight: bold;
-  border-bottom: 1px solid #ddd;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 15px;
+	background-color: #061524;
+	color: #ffffff;
+	font-size: calc(var(--font-size-desktop) * 1.2);
+	font-weight: bold;
+	border-bottom: 1px solid #ddd;
 }
 
 /* Tool content styling */
 .tool-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 20px;
-  background-color: #f9f9f9;
-  color: #333333;
-  gap: 20px;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	padding: 20px;
+	background-color: #f9f9f9;
+	color: #333333;
+	gap: 20px;
 }
 
 /* Input and output text areas */
 .input-area,
 .output-area {
-  padding: 10px;
-  border: 1px solid #dddddd;
-  border-radius: 4px;
-  font-family: monospace;
-  font-size: calc(var(--font-size-desktop) * 1);
-  resize: none;
+	padding: 10px;
+	border: 1px solid #dddddd;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: calc(var(--font-size-desktop) * 1);
+	resize: none;
 }
 
 /* Read-only style for output area */
 .output-area[readonly] {
-  background-color: #e9e9e9;
+	background-color: #e9e9e9;
 }
 
 /* Format button styling */
 .convert-utc-btn {
-  align-self: center;
-  padding: 10px 20px;
-  background-color: #061524;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: calc(var(--font-size-desktop) * 1);
-  transition:
-    background-color 0.3s ease,
-    transform 0.2s ease;
+	align-self: center;
+	padding: 10px 20px;
+	background-color: #061524;
+	color: #ffffff;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: calc(var(--font-size-desktop) * 1);
+	transition:
+		background-color 0.3s ease,
+		transform 0.2s ease;
 }
 
 .convert-utc-btn:hover {
-  background-color: #34495e;
-  transform: scale(1.05);
+	background-color: #34495e;
+	transform: scale(1.05);
 }
 
 .convert-iso-btn {
-  align-self: center;
-  padding: 10px 20px;
-  background-color: #061524;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: calc(var(--font-size-desktop) * 1);
-  transition:
-    background-color 0.3s ease,
-    transform 0.2s ease;
+	align-self: center;
+	padding: 10px 20px;
+	background-color: #061524;
+	color: #ffffff;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: calc(var(--font-size-desktop) * 1);
+	transition:
+		background-color 0.3s ease,
+		transform 0.2s ease;
 }
 
 .convert-iso-btn:hover {
-  background-color: #34495e;
-  transform: scale(1.05);
+	background-color: #34495e;
+	transform: scale(1.05);
 }
 
 .button-group {
-  display: flex;
-  justify-content: center;
-  gap: 15px; /* Adds space between buttons */
+	display: flex;
+	justify-content: center;
+	gap: 15px; /* Adds space between buttons */
 }
 
 @media (max-width: 600px) {
-  .tool-panel {
-    font-size: var(--font-size-mobile); /* Mobile font size */
-  }
+	.tool-panel {
+		font-size: var(--font-size-mobile); /* Mobile font size */
+	}
 
-  .tool-header {
-    font-size: var(--font-size-mobile); /* Mobile font size */
-  }
+	.tool-header {
+		font-size: var(--font-size-mobile); /* Mobile font size */
+	}
 
-  .button-group {
-    flex-direction: column;
-    /* Stack buttons vertically on smaller screens */
-    gap: 10px;
-    /* Adjust spacing for mobile view */
-  }
+	.button-group {
+		flex-direction: column;
+		/* Stack buttons vertically on smaller screens */
+		gap: 10px;
+		/* Adjust spacing for mobile view */
+	}
 }

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
@@ -1,16 +1,16 @@
 class UnixTimestampConverterTool extends HTMLElement {
-	constructor() {
-		super();
-		this.toolPanel = null;
-		this.convertUtcBtn = null;
-		this.convertIsoBtn = null;
-		this.inputArea = null;
-		this.outputArea = null;
-	}
+  constructor() {
+    super();
+    this.toolPanel = null;
+    this.convertUtcBtn = null;
+    this.convertIsoBtn = null;
+    this.inputArea = null;
+    this.outputArea = null;
+  }
 
-	connectedCallback() {
-		// Set up the HTML structure when the element is added to the DOM
-		this.innerHTML = `
+  connectedCallback() {
+    // Set up the HTML structure when the element is added to the DOM
+    this.innerHTML = `
             <link rel="stylesheet" href="unix-timestamp-converter/unix-timestamp-converter-tool.css"> 
             <section class="tool-panel" style="display:none;">
               <header class="tool-header">
@@ -27,52 +27,52 @@ class UnixTimestampConverterTool extends HTMLElement {
             </section>
           `;
 
-		// Store references to elements
-		this.toolPanel = this.querySelector(".tool-panel");
-		this.convertUtcBtn = this.querySelector(".convert-utc-btn");
-		this.convertIsoBtn = this.querySelector(".convert-iso-btn");
-		this.inputArea = this.querySelector(".input-area");
-		this.outputArea = this.querySelector(".output-area");
+    // Store references to elements
+    this.toolPanel = this.querySelector(".tool-panel");
+    this.convertUtcBtn = this.querySelector(".convert-utc-btn");
+    this.convertIsoBtn = this.querySelector(".convert-iso-btn");
+    this.inputArea = this.querySelector(".input-area");
+    this.outputArea = this.querySelector(".output-area");
 
-		// Bind event listeners
-		this.convertUtcBtn.addEventListener("click", () => this.convertTime("utc"));
-		this.convertIsoBtn.addEventListener("click", () => this.convertTime("iso"));
-	}
+    // Bind event listeners
+    this.convertUtcBtn.addEventListener("click", () => this.convertTime("utc"));
+    this.convertIsoBtn.addEventListener("click", () => this.convertTime("iso"));
+  }
 
-	convertTime = (format) => {
-		try {
-			const input = this.inputArea.value;
-			const unixTimestamp = parseInt(input, 10);
+  convertTime = (format) => {
+    try {
+      const input = this.inputArea.value;
+      const unixTimestamp = parseInt(input, 10);
 
-			// More specific error handling
-			if (isNaN(unixTimestamp)) {
-				throw new Error("Invalid Unix timestamp");
-			}
+      // More specific error handling
+      if (isNaN(unixTimestamp)) {
+        throw new Error("Invalid Unix timestamp");
+      }
 
-			const date = new Date(unixTimestamp * 1000);
+      const date = new Date(unixTimestamp * 1000);
 
-			// output based on format inputted
-			if (format == "utc") {
-				this.outputArea.value = date.toUTCString();
-			} else if (format == "iso") {
-				this.outputArea.value = date.toISOString();
-			}
-		} catch (error) {
-			this.outputArea.value = `Error: ${error.message}`;
-		}
-	};
+      // output based on format inputted
+      if (format == "utc") {
+        this.outputArea.value = date.toUTCString();
+      } else if (format == "iso") {
+        this.outputArea.value = date.toISOString();
+      }
+    } catch (error) {
+      this.outputArea.value = `Error: ${error.message}`;
+    }
+  };
 
-	disconnectedCallback() {
-		// Clean up event listeners when the element is removed from the DOM
-		if (this.convertUtcBtn)
-			this.convertUtcBtn.removeEventListener("click", this.convertTime);
-		if (this.convertIsoBtn)
-			this.convertIsoBtn.removeEventListener("click", this.convertTime);
-	}
+  disconnectedCallback() {
+    // Clean up event listeners when the element is removed from the DOM
+    if (this.convertUtcBtn)
+      this.convertUtcBtn.removeEventListener("click", this.convertTime);
+    if (this.convertIsoBtn)
+      this.convertIsoBtn.removeEventListener("click", this.convertTime);
+  }
 }
 
 // Register the custom element
 customElements.define(
-	"unix-timestamp-converter-tool",
-	UnixTimestampConverterTool
+  "unix-timestamp-converter-tool",
+  UnixTimestampConverterTool,
 );

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
@@ -57,8 +57,6 @@ class UnixTimestampConverterTool extends HTMLElement {
         this.outputArea.value = date.toUTCString();
       } else if (format == "iso") {
         this.outputArea.value = date.toISOString();
-      } else {
-        throw new Error("Unsupported format");
       }
     } catch (error) {
       this.outputArea.value = `Error: ${error.message}`;
@@ -77,5 +75,5 @@ class UnixTimestampConverterTool extends HTMLElement {
 // Register the custom element
 customElements.define(
   "unix-timestamp-converter-tool",
-  UnixTimestampConverterTool
+  UnixTimestampConverterTool,
 );

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
@@ -1,18 +1,18 @@
 class UnixTimestampConverterTool extends HTMLElement {
-  constructor() {
-    super();
-    this.toolPanel = null;
-    this.convertUtcBtn = null;
-    this.convertIsoBtn = null;
-    this.inputArea = null;
-    this.outputArea = null;
-  }
+	constructor() {
+		super();
+		this.toolPanel = null;
+		this.convertUtcBtn = null;
+		this.convertIsoBtn = null;
+		this.inputArea = null;
+		this.outputArea = null;
+	}
 
-  connectedCallback() {
-    // Set up the HTML structure when the element is added to the DOM
-    this.innerHTML = `
+	connectedCallback() {
+		// Set up the HTML structure when the element is added to the DOM
+		this.innerHTML = `
             <link rel="stylesheet" href="unix-timestamp-converter/unix-timestamp-converter-tool.css"> 
-            <section class="tool-panel">
+            <section class="tool-panel" style="display:none;">
               <header class="tool-header">
                 <h3>UNIX Timestamp Converter</h3>
               </header>
@@ -28,52 +28,52 @@ class UnixTimestampConverterTool extends HTMLElement {
             </section>
           `;
 
-    // Store references to elements
-    this.toolPanel = this.querySelector(".tool-panel");
-    this.convertUtcBtn = this.querySelector(".convert-utc-btn");
-    this.convertIsoBtn = this.querySelector(".convert-iso-btn");
-    this.inputArea = this.querySelector(".input-area");
-    this.outputArea = this.querySelector(".output-area");
+		// Store references to elements
+		this.toolPanel = this.querySelector(".tool-panel");
+		this.convertUtcBtn = this.querySelector(".convert-utc-btn");
+		this.convertIsoBtn = this.querySelector(".convert-iso-btn");
+		this.inputArea = this.querySelector(".input-area");
+		this.outputArea = this.querySelector(".output-area");
 
-    // Bind event listeners
-    this.convertUtcBtn.addEventListener("click", () => this.convertTime("utc"));
-    this.convertIsoBtn.addEventListener("click", () => this.convertTime("iso"));
-  }
+		// Bind event listeners
+		this.convertUtcBtn.addEventListener("click", () => this.convertTime("utc"));
+		this.convertIsoBtn.addEventListener("click", () => this.convertTime("iso"));
+	}
 
-  convertTime = (format) => {
-    try {
-      const input = this.inputArea.value;
-      const unixTimestamp = parseInt(input, 10);
+	convertTime = (format) => {
+		try {
+			const input = this.inputArea.value;
+			const unixTimestamp = parseInt(input, 10);
 
-      // More specific error handling
-      if (isNaN(unixTimestamp)) {
-        throw new Error("Invalid Unix timestamp");
-      }
+			// More specific error handling
+			if (isNaN(unixTimestamp)) {
+				throw new Error("Invalid Unix timestamp");
+			}
 
-      const date = new Date(unixTimestamp * 1000);
+			const date = new Date(unixTimestamp * 1000);
 
-      // output based on format inputted
-      if (format == "utc") {
-        this.outputArea.value = date.toUTCString();
-      } else if (format == "iso") {
-        this.outputArea.value = date.toISOString();
-      }
-    } catch (error) {
-      this.outputArea.value = `Error: ${error.message}`;
-    }
-  };
+			// output based on format inputted
+			if (format == "utc") {
+				this.outputArea.value = date.toUTCString();
+			} else if (format == "iso") {
+				this.outputArea.value = date.toISOString();
+			}
+		} catch (error) {
+			this.outputArea.value = `Error: ${error.message}`;
+		}
+	};
 
-  disconnectedCallback() {
-    // Clean up event listeners when the element is removed from the DOM
-    if (this.convertUtcBtn)
-      this.convertUtcBtn.removeEventListener("click", this.convertTime);
-    if (this.convertIsoBtn)
-      this.convertIsoBtn.removeEventListener("click", this.convertTime);
-  }
+	disconnectedCallback() {
+		// Clean up event listeners when the element is removed from the DOM
+		if (this.convertUtcBtn)
+			this.convertUtcBtn.removeEventListener("click", this.convertTime);
+		if (this.convertIsoBtn)
+			this.convertIsoBtn.removeEventListener("click", this.convertTime);
+	}
 }
 
 // Register the custom element
 customElements.define(
-  "unix-timestamp-converter-tool",
-  UnixTimestampConverterTool,
+	"unix-timestamp-converter-tool",
+	UnixTimestampConverterTool
 );

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.js
@@ -2,7 +2,8 @@ class UnixTimestampConverterTool extends HTMLElement {
   constructor() {
     super();
     this.toolPanel = null;
-    this.convertBtn = null;
+    this.convertUtcBtn = null;
+    this.convertIsoBtn = null;
     this.inputArea = null;
     this.outputArea = null;
   }
@@ -13,12 +14,15 @@ class UnixTimestampConverterTool extends HTMLElement {
             <link rel="stylesheet" href="unix-timestamp-converter/unix-timestamp-converter-tool.css"> 
             <section class="tool-panel">
               <header class="tool-header">
-                <h3>UNIX to UTC</h3>
+                <h3>UNIX Timestamp Converter</h3>
               </header>
               <hr />
               <section class="tool-content">
                 <textarea class="input-area" placeholder="Paste your UNIX timestamp here"></textarea>
-                <button class="convert-btn">Convert</button>
+                <div class="button-group">
+                    <button class="convert-utc-btn">Convert to UTC</button>
+                    <button class="convert-iso-btn">Convert to ISO</button>
+                </div>
                 <textarea class="output-area" readonly></textarea>
               </section>
             </section>
@@ -26,16 +30,17 @@ class UnixTimestampConverterTool extends HTMLElement {
 
     // Store references to elements
     this.toolPanel = this.querySelector(".tool-panel");
-    this.convertBtn = this.querySelector(".convert-btn");
+    this.convertUtcBtn = this.querySelector(".convert-utc-btn");
+    this.convertIsoBtn = this.querySelector(".convert-iso-btn");
     this.inputArea = this.querySelector(".input-area");
     this.outputArea = this.querySelector(".output-area");
 
     // Bind event listeners
-    this.convertBtn.addEventListener("click", () => this.convertUNIX());
+    this.convertUtcBtn.addEventListener("click", () => this.convertTime("utc"));
+    this.convertIsoBtn.addEventListener("click", () => this.convertTime("iso"));
   }
 
-  // how is the documentation getting added with JSDocs? Is this on push to main?
-  convertUNIX = () => {
+  convertTime = (format) => {
     try {
       const input = this.inputArea.value;
       const unixTimestamp = parseInt(input, 10);
@@ -46,7 +51,15 @@ class UnixTimestampConverterTool extends HTMLElement {
       }
 
       const date = new Date(unixTimestamp * 1000);
-      this.outputArea.value = date.toUTCString();
+
+      // output based on format inputted
+      if (format == "utc") {
+        this.outputArea.value = date.toUTCString();
+      } else if (format == "iso") {
+        this.outputArea.value = date.toISOString();
+      } else {
+        throw new Error("Unsupported format");
+      }
     } catch (error) {
       this.outputArea.value = `Error: ${error.message}`;
     }
@@ -54,13 +67,15 @@ class UnixTimestampConverterTool extends HTMLElement {
 
   disconnectedCallback() {
     // Clean up event listeners when the element is removed from the DOM
-    if (this.convertBtn)
-      this.convertBtn.removeEventListener("click", this.convertUNIX);
+    if (this.convertUtcBtn)
+      this.convertUtcBtn.removeEventListener("click", this.convertTime);
+    if (this.convertIsoBtn)
+      this.convertIsoBtn.removeEventListener("click", this.convertTime);
   }
 }
 
 // Register the custom element
 customElements.define(
   "unix-timestamp-converter-tool",
-  UnixTimestampConverterTool,
+  UnixTimestampConverterTool
 );

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.test.js
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.test.js
@@ -1,0 +1,83 @@
+require("./unix-timestamp-converter-tool");
+
+describe("UnixTimestampConverterTool", () => {
+  let unixTimestampConverterTool;
+  let inputArea;
+  let outputArea;
+  let convertUtcBtn;
+  let convertIsoBtn;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+        <unix-timestamp-converter-tool></unix-timestamp-converter-tool>
+      `;
+
+    // Get references to elements inside the custom element
+    unixTimestampConverterTool = document.querySelector(
+      "unix-timestamp-converter-tool"
+    );
+    inputArea = unixTimestampConverterTool.querySelector(".input-area");
+    outputArea = unixTimestampConverterTool.querySelector(".output-area");
+    convertUtcBtn =
+      unixTimestampConverterTool.querySelector(".convert-utc-btn");
+    convertIsoBtn =
+      unixTimestampConverterTool.querySelector(".convert-iso-btn");
+  });
+
+  test("Should render the UNIX timestamp converter tool correctly", () => {
+    expect(inputArea).toBeTruthy();
+    expect(convertUtcBtn).toBeTruthy();
+    expect(convertIsoBtn).toBeTruthy();
+    expect(outputArea).toBeTruthy();
+  });
+
+  test("should convert to UTC properly when convert UTC button is clicked", () => {
+    // Input valid UNIX timestamp and trigger the convert UTC button
+    inputArea.value = "919191919";
+    convertUtcBtn.click();
+
+    // Check that the output area contains the correct UTC timestamp
+    expect(outputArea.value).toBe("Tue, 16 Feb 1999 19:05:19 GMT");
+  });
+
+  test("should convert to ISO properly when convert ISO button is clicked", () => {
+    // Input valid UNIX timestamp and trigger the convert ISO button
+    inputArea.value = "919191919";
+    convertIsoBtn.click();
+
+    // Check that the output area contains the correct UTC timestamp
+    expect(outputArea.value).toBe("1999-02-16T19:05:19.000Z");
+  });
+
+  test("should error out of UTC conversion when input is empty", () => {
+    inputArea.value = "";
+    convertUtcBtn.click();
+
+    //The output should be empty
+    expect(outputArea.value).toBe("Error: Invalid Unix timestamp");
+  });
+
+  test("should error out of ISO conversion when input is empty", () => {
+    inputArea.value = "";
+    convertIsoBtn.click();
+
+    //The output should be empty
+    expect(outputArea.value).toBe("Error: Invalid Unix timestamp");
+  });
+
+  test("should indicate error when converting invalid timestamp to UTC", () => {
+    inputArea.value = "abc12345";
+    convertUtcBtn.click();
+
+    // Check that the output area shows the error
+    expect(outputArea.value).toBe("Error: Invalid Unix timestamp");
+  });
+
+  test("should indicate error when converting invalid timestamp to ISO", () => {
+    inputArea.value = "abc12345";
+    convertIsoBtn.click();
+
+    // Check that the output area shows the error
+    expect(outputArea.value).toBe("Error: Invalid Unix timestamp");
+  });
+});

--- a/src/unix-timestamp-converter/unix-timestamp-converter-tool.test.js
+++ b/src/unix-timestamp-converter/unix-timestamp-converter-tool.test.js
@@ -14,7 +14,7 @@ describe("UnixTimestampConverterTool", () => {
 
     // Get references to elements inside the custom element
     unixTimestampConverterTool = document.querySelector(
-      "unix-timestamp-converter-tool"
+      "unix-timestamp-converter-tool",
     );
     inputArea = unixTimestampConverterTool.querySelector(".input-area");
     outputArea = unixTimestampConverterTool.querySelector(".output-area");


### PR DESCRIPTION
## Description

Updated so that CSS is rendered before the HTML, preventing HTML from showing first. Additional test cases added too, and ISO formatting support.

## Related Issue

- Works on #[92]

## Checklist

- [x] Code compiles without errors.
- [x] All tests pass.
- [x] Documentation has been updated as necessary.
