### PR TITLE
Added static placeholder

### DIFF
--- a/src/uuid-generator/uuid-generator-tool.js
+++ b/src/uuid-generator/uuid-generator-tool.js
@@ -19,7 +19,7 @@ class UUIDGeneratorTool extends HTMLElement {
                 <h3>UUID Generator</h3>
             </header>
             <section class="tool-content">
-                <textarea class="output-area" placeholder="\n91ce19ea-0e4b-4064-a38a-6dcdde6b81fc" readonly></textarea>
+                <textarea class="output-area" placeholder="\nClick Below to Generate a UUID" readonly></textarea>
                 <div align="center" class="button-group">
                     <button class="generate-btn">Generate UUID</button>
                     <div class="copy-btn-container">

--- a/src/uuid-generator/uuid-generator-tool.js
+++ b/src/uuid-generator/uuid-generator-tool.js
@@ -19,7 +19,7 @@ class UUIDGeneratorTool extends HTMLElement {
                 <h3>UUID Generator</h3>
             </header>
             <section class="tool-content">
-                <textarea class="output-area" readonly></textarea>
+                <textarea class="output-area" placeholder="\n91ce19ea-0e4b-4064-a38a-6dcdde6b81fc" readonly></textarea>
                 <div align="center" class="button-group">
                     <button class="generate-btn">Generate UUID</button>
                     <div class="copy-btn-container">


### PR DESCRIPTION
## Description

The UUID should have a placeholder uuid when the page loads.

## Related Issue

- Closes #102 

## Changes Made

- Added a static placeholder UUID on load

## Checklist

- [X] Code compiles without errors.
- [X] All tests pass.
- [X] Documentation has been updated as necessary.

## Testing Instructions

Load the page and see if a UUID is there when you select the tool.
